### PR TITLE
Improve checking that slapd is up and ready

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -114,7 +114,9 @@ function runInitScript {
     do
         ldapwhoami -D "cn=admin,${BASEDN}" -w "${PASSWORD}"
         exit_code=$?
+        echo "Exit code is: ${exit_code}"
         sleep 1
+        echo "Done sleeping 1"
     done
 
     echo "run initialization script"

--- a/start.sh
+++ b/start.sh
@@ -112,7 +112,7 @@ function runInitScript {
     exit_code=1
     while [ $exit_code -ne 0 ]
     do
-        ldapurl
+        ldapwhoami -D "cn=admin,${BASEDN}" -w "${PASSWORD}"
         exit_code=$?
         sleep 1
     done

--- a/start.sh
+++ b/start.sh
@@ -109,11 +109,8 @@ fi
 function runInitScript {
 
     echo "wait server for initializing"
-    exit_code=1
     until ldapwhoami -D "cn=admin,${BASEDN}" -w "${PASSWORD}"; do
-        echo "Sleeping 1"
         sleep 1
-        echo "Done sleeping 1"
     done
 
     echo "run initialization script"

--- a/start.sh
+++ b/start.sh
@@ -110,11 +110,8 @@ function runInitScript {
 
     echo "wait server for initializing"
     exit_code=1
-    while [ $exit_code -ne 0 ]
-    do
-        ldapwhoami -D "cn=admin,${BASEDN}" -w "${PASSWORD}"
-        exit_code=$?
-        echo "Exit code is: ${exit_code}"
+    until ldapwhoami -D "cn=admin,${BASEDN}" -w "${PASSWORD}"; do
+        echo "Sleeping 1"
         sleep 1
         echo "Done sleeping 1"
     done


### PR DESCRIPTION
I'm substituting using an `until` loop for the `while` loop, as it's cleaner and does what I need to without temporary variables, and less LOC.

But ultimately we have to have a valid test to assure us that the `slapd` process is in fact up and responding to queries before we can run an `ldapmodify` against it. The ability to run the below `ldapwhoami` query against the `slapd` process positively indicates that the server is ready to process the `ldapmodify` command below it.

Closes #11 