### PR TITLE
Use PASSWORD_HASH to initialize ppolicy plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mwaeckerlin/base
 MAINTAINER mwaeckerlin
 ARG backend="mdb"
-ARG overlays=""
+ARG overlays="openldap-overlay-ppolicy"
 ENV DOMAIN                    ""
 ENV PASSWORD                  ""
 ENV DEBUG                     1

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Environment Variables:
     Specifies the debug level, defaults to 0 (no debug output)
 - `INDEXES` (optional) 
     A list of indexes that the LDAP server should maintain, separated by spaces, e.g.: ` index uid eq index cn eq`.
+- `PASSWORD_HASH` (optional) 
+    A password hashing scheme for the openldap server when storing passwords (see [the docs](https://openldap.org/doc/admin24/security.html#Password%20Storage) for more info). Options are:
+    * `SSHA`
+    * `CRYPT`
+    * `MD5`
+    * `SMD5`
+    * `SHA`
 
 Ports:
 - 389 (LDAP and LDAP+startTLS)

--- a/start.sh
+++ b/start.sh
@@ -57,6 +57,22 @@ memberof-memberof-ad memberOf
 memberof-refint true
 EOF
 fi
+if test -n "${PASSWORD_HASH}"; then
+    case "${PASSWORD_HASH}" in
+        SSHA|CRYPT|MD5|SMD5|SHA)
+            echo "include /etc/openldap/schema/ppolicy.schema" >> /etc/ldap/slapd.conf
+            cat >> /etc/ldap/slapd.conf <<EOF
+moduleload ppolicy
+overlay ppolicy
+ppolicy_hash_cleartext
+password-hash {${PASSWORD_HASH}}
+EOF
+            ;;
+        *)
+            error "PASSWORD_HASH not one of 'SSHA, CRYPT, MD5, SMD5, SHA'"
+            ;;
+    esac
+fi
 for schema in $SCHEMAS; do
     echo "include /etc/openldap/schema/${schema}.schema" >> /etc/ldap/slapd.conf
 done


### PR DESCRIPTION
This PR adds the ability to hash passwords at rest using one of several hashing algorithms.

While this does not set up a way to customize `ppolicy` in general, it does require that it be installed and initially configures it to hash plaintext passwords.